### PR TITLE
jAdd notify and reorganize null-ls

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -159,6 +159,11 @@ require("packer").startup({
 
         use({ "L3MON4D3/LuaSnip" })
 
+        use(
+            { "mfussenegger/nvim-dap" }
+            -- main debugger plugin
+        )
+
         --  _   _ ___
         -- | | | |_ _|
         -- | | | || |
@@ -385,6 +390,9 @@ function _G.ReloadConfig()
     vim.notify("Nvim configuration reloaded!")
 end
 vim.keymap.set("n", "<Leader><Leader>r", "<Cmd>lua ReloadConfig()<CR>", { silent = true, noremap = true })
+
+vim.keymap.set("n", "<Leader><Leader>s", "<Cmd>PackerSync<CR>", { noremap = true })
+
 --           _
 --  ___ ___ | | ___  _ __ ___
 -- / __/ _ \| |/ _ \| '__/ __|

--- a/.config/nvim/lua/aw/completion.lua
+++ b/.config/nvim/lua/aw/completion.lua
@@ -85,11 +85,3 @@ cmp.setup.cmdline(":", {
     mapping = cmp.mapping.preset.cmdline(),
     sources = cmp.config.sources({ { name = "path" } }, { { name = "cmdline" } }),
 })
-
-local setup_buffer_completion = function()
-    cmp.setup.buffer({
-        sources = {
-            name = "buffer",
-        },
-    })
-end

--- a/.config/nvim/lua/aw/lsp/init.lua
+++ b/.config/nvim/lua/aw/lsp/init.lua
@@ -8,7 +8,7 @@
 -- global diagnostics configuration
 vim.diagnostic.config({
     virtual_text = false,
-    update_in_insert = false
+    update_in_insert = false,
 })
 
 local configured_servers = { "null-ls", "sumneko-lua", "pyright" }
@@ -17,4 +17,4 @@ for _, server in ipairs(configured_servers) do
     require("aw.lsp." .. server)
 end
 
-require('aw.completion')
+require("aw.completion")

--- a/.config/nvim/lua/aw/lsp/null-ls.lua
+++ b/.config/nvim/lua/aw/lsp/null-ls.lua
@@ -7,45 +7,50 @@ local builtins = require("null-ls.builtins")
 
 local writing_filetypes = { "markdown", "vimwiki" }
 
+local on_attach = function(client, bufnr)
+    common.on_attach(client, bufnr)
+    -- null-ls formatting
+    local augroup = vim.api.nvim_create_augroup("LspFormatting", {})
+    if client.supports_method("textDocument/formatting") then
+        vim.api.nvim_clear_autocmds({ group = augroup, buffer = bufnr })
+        vim.api.nvim_create_autocmd("BufWritePre", {
+            group = augroup,
+            buffer = bufnr,
+            callback = function()
+                vim.lsp.buf.format({ bufnr = bufnr })
+            end,
+        })
+    end
+    vim.notify("Loaded Null-ls language server!")
+end
+
+local sources = {
+    builtins.code_actions.refactoring,
+    builtins.diagnostics.cppcheck,
+
+    -- python-related
+    builtins.diagnostics.flake8,
+    builtins.formatting.isort,
+    builtins.formatting.black,
+
+    -- markdown formatting
+    builtins.diagnostics.markdownlint.with({
+        extra_filetypes = writing_filetypes,
+    }),
+    builtins.formatting.prettier.with({
+        extra_args = { "--prose-wrap", "always" },
+        extra_filetypes = writing_filetypes,
+    }),
+
+    -- lua formatting
+    builtins.formatting.stylua,
+
+    -- sh and zsh
+    builtins.diagnostics.zsh,
+}
+
 null_ls.setup({
-    debug = true,
-    on_attach = function(client, bufnr)
-        common.on_attach(client, bufnr)
-        -- null-ls formatting
-        local augroup = vim.api.nvim_create_augroup("LspFormatting", {})
-        if client.supports_method("textDocument/formatting") then
-            vim.api.nvim_clear_autocmds({ group = augroup, buffer = bufnr })
-            vim.api.nvim_create_autocmd("BufWritePre", {
-                group = augroup,
-                buffer = bufnr,
-                callback = function()
-                    -- on 0.8, you should use vim.lsp.buf.format({ bufnr = bufnr }) instead
-                    vim.lsp.buf.format({ bufnr = bufnr })
-                end,
-            })
-        end
-    end,
-    sources = {
-        builtins.code_actions.refactoring,
-        builtins.diagnostics.cppcheck,
-
-        -- python-related
-        builtins.diagnostics.flake8,
-        builtins.formatting.isort,
-        builtins.formatting.black,
-
-        -- markdown formatting
-        builtins.diagnostics.markdownlint.with({
-            filetypes = writing_filetypes,
-        }),
-        builtins.formatting.prettier.with({
-            extra_args = { "--prose-wrap", "always" },
-        }),
-
-        -- lua formatting
-        builtins.formatting.stylua,
-
-        -- sh and zsh
-        builtins.diagnostics.zsh,
-    },
+    debug = false,
+    on_attach = on_attach,
+    sources = sources,
 })

--- a/.config/nvim/lua/aw/lsp/pyright.lua
+++ b/.config/nvim/lua/aw/lsp/pyright.lua
@@ -1,8 +1,13 @@
 local lspconfig = require("lspconfig")
 local common = require("aw.lsp.common")
 
+local on_attach = function(client, bufnr)
+    common.on_attach(client, bufnr)
+    vim.notify("Loaded Pyright language server!")
+end
+
 -- pyright
 lspconfig.pyright.setup({
-    on_attach = common.on_attach,
+    on_attach = on_attach,
     capabilities = common.capabilities,
 })

--- a/.config/nvim/lua/aw/lsp/sumneko-lua.lua
+++ b/.config/nvim/lua/aw/lsp/sumneko-lua.lua
@@ -5,6 +5,8 @@ local on_attach = function(client, bufnr)
     common.on_attach(client, bufnr)
     client.server_capabilities.document_formatting = false
     client.server_capabilities.document_range_formatting = false
+
+    vim.notify("Loaded Lua language server!")
 end
 
 local capabilities = common.capabilities

--- a/.config/nvim/lua/aw/octo.lua
+++ b/.config/nvim/lua/aw/octo.lua
@@ -22,19 +22,18 @@ octo.setup({
             create_label = { lhs = "<Leader>lc", desc = "create label" },
             add_label = { lhs = "<Leader>la", desc = "add label" },
             remove_label = { lhs = "<Leader>ld", desc = "remove label" },
-            goto_issue = { lhs = "<Leader>gi", desc = "navigate to a local repo issue" },
-            add_comment = { lhs = "<Leader>ca", desc = "add comment" },
+            add_comment = { lhs = "<Leader>ac", desc = "add comment" },
             delete_comment = { lhs = "<Leader>cd", desc = "delete comment" },
             next_comment = { lhs = "]c", desc = "go to next comment" },
             prev_comment = { lhs = "[c", desc = "go to previous comment" },
-            react_hooray = { lhs = "<Leader>rp", desc = "add/remove 🎉 reaction" },
+            react_hooray = { lhs = "<Leader>ry", desc = "add/remove 🎉 reaction" },
+            react_laugh = { lhs = "<Leader>rl", desc = "add/remove 😄 reaction" },
+            react_confused = { lhs = "<Leader>rc", desc = "add/remove 😕 reaction" },
             --react_heart = { lhs = "<Leader>rh", desc = "add/remove ❤️ reaction" },
             --react_eyes = { lhs = "<Leader>re", desc = "add/remove 👀 reaction" },
             --react_thumbs_up = { lhs = "<Leader>r+", desc = "add/remove 👍 reaction" },
             --react_thumbs_down = { lhs = "<Leader>r-", desc = "add/remove 👎 reaction" },
             --react_rocket = { lhs = "<Leader>rr", desc = "add/remove 🚀 reaction" },
-            react_laugh = { lhs = "<Leader>rl", desc = "add/remove 😄 reaction" },
-            react_confused = { lhs = "<Leader>rc", desc = "add/remove 😕 reaction" },
         },
     },
 })
@@ -43,4 +42,4 @@ local opts = { noremap = true }
 
 vim.keymap.set("n", "<Leader>li", "<Cmd>Octo issue list<CR>", opts)
 vim.keymap.set("n", "<Leader>nc", "<Cmd>Octo comment add<CR>", opts)
-vim.keymap.set("n", "<Leader>lc", "<Cmd>Octo issue create<CR>", opts)
+vim.keymap.set("n", "<Leader>nc", "<Cmd>Octo issue create<CR>", opts)


### PR DESCRIPTION
This PR 

1. Adds more notifications when language servers are loaded,
2. Adds a keymap for `PackerSync`,
3. Reorganizes the Null-ls configuration,
4. Removes a dead function from completion configuration

Also, nvim-dap is added, but not configured/set up, so it won't yet do anything.